### PR TITLE
fixed update customer method

### DIFF
--- a/lib/groovehq/client/customers.rb
+++ b/lib/groovehq/client/customers.rb
@@ -3,8 +3,8 @@ module GrooveHQ
 
     module Customers
 
-      def update_customer(options)
-        post("/tickets/#{ticket_number}/messages", options)
+      def update_customer(email, options)
+        put("/customers/#{email}", options)
       end
 
       def customer(email)


### PR DESCRIPTION
Just noticed that the `update_customer` method called a wrong api endpoint (ticket messages). I added *email* to method params. You identify the customer by `email` and whatever you want to update is passed in via the `options` hash. It's working in my rails 4.2.5 app.

See groovehq api doc: https://www.groovehq.com/docs/customers#updating-a-customer

Would be great if this would be released shortly on rubygems in a version 1.0.4 :) thanks!