### PR TITLE
Move bin to exe

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 group :test do
+  gem 'pry'
   gem 'rspec'
   gem 'webmock'
 end

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "groovehq"
+
+require "pry"
+Pry.start

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/groovehq.gemspec
+++ b/groovehq.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.0'


### PR DESCRIPTION
[Recent changes in bundler](http://bundler.io/blog/2015/03/20/moving-bins-to-exe.html) establish the convention of setting the executable dir to `exe` so bundle binstubs can be used for development from the `bin` directory. 

This PR makes the needed change in the gemspec and adds some helpfu binstubs to `bin`.