### PR TITLE
Paginated collection

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,8 @@ begin
   require 'rspec/core/rake_task'
 
   RSpec::Core::RakeTask.new(:spec) do |t|
-    t.rspec_opts = ["--tag=~integration"] unless ENV["TRAVIS_BRANCH"] == "master"
+    travis_master = ENV["TRAVIS_BRANCH"] == "master" && ENV["TRAVIS_PULL_REQUEST"] == "false"
+    t.rspec_opts = ["--tag=~integration"] unless travis_master
   end
 
   task :default => :spec

--- a/lib/groovehq/resource.rb
+++ b/lib/groovehq/resource.rb
@@ -20,7 +20,7 @@ module GrooveHQ
 
     def parse_links(links)
       (links || {}).each_with_object({}) do |(relation, value), result|
-        result[relation] = Relation.new(@client, value[:href])
+        result[relation] = Relation.new(@client, value[:href]) if value[:href]
       end.with_indifferent_access
     end
 

--- a/lib/groovehq/resource_collection.rb
+++ b/lib/groovehq/resource_collection.rb
@@ -38,7 +38,11 @@ module GrooveHQ
       collection.each { |item| yield item }
 
       rel = @rels[:next] or return self
-      rel.get.each(&Proc.new)
+      coll = rel.get
+      coll.each(&Proc.new)
+
+      @data = OpenStruct.new(meta: coll.meta, collection: collection + coll.collection)
+      @rels = coll.rels
     end
 
   end

--- a/lib/groovehq/resource_collection.rb
+++ b/lib/groovehq/resource_collection.rb
@@ -3,7 +3,9 @@ module GrooveHQ
   class ResourceCollection < Resource
     include Enumerable
 
-    def initialize(client, data)
+    attr_reader :options
+
+    def initialize(client, data, options = {})
       data = {} unless data.is_a?(Hash)
       data = data.with_indifferent_access
 
@@ -30,6 +32,7 @@ module GrooveHQ
 
       @data = OpenStruct.new(meta: meta_data, collection: collection)
       @rels = parse_links(links)
+      @options = options.with_indifferent_access
     end
 
     def each
@@ -38,7 +41,7 @@ module GrooveHQ
       collection.each { |item| yield item }
 
       rel = @rels[:next] or return self
-      coll = rel.get
+      coll = rel.get(@options.except(:page))
       coll.each(&Proc.new)
 
       @data = OpenStruct.new(meta: coll.meta, collection: collection + coll.collection)

--- a/lib/groovehq/resource_collection.rb
+++ b/lib/groovehq/resource_collection.rb
@@ -25,17 +25,20 @@ module GrooveHQ
           prev: {
             href: meta_data["pagination"]["prev_page"]
           }
-        }.with_indifferent_access
+        }
       end
 
       @data = OpenStruct.new(meta: meta_data, collection: collection)
       @rels = parse_links(links)
     end
 
-    def each(&block)
+    def each
       return enum_for(:each) unless block_given?
 
       collection.each { |item| yield item }
+
+      rel = @rels[:next] or return self
+      rel.get.each(&Proc.new)
     end
 
   end

--- a/lib/groovehq/resource_collection.rb
+++ b/lib/groovehq/resource_collection.rb
@@ -41,11 +41,12 @@ module GrooveHQ
       collection.each { |item| yield item }
 
       rel = @rels[:next] or return self
-      coll = rel.get(@options.except(:page))
-      coll.each(&Proc.new)
+      resource_collection = rel.get(@options.except(:page))
+      resource_collection.each(&Proc.new)
 
-      @data = OpenStruct.new(meta: coll.meta, collection: collection + coll.collection)
-      @rels = coll.rels
+      @data = OpenStruct.new(meta: resource_collection.meta,
+                             collection: collection + resource_collection.collection)
+      @rels = resource_collection.rels
     end
 
   end

--- a/lib/groovehq/resource_collection.rb
+++ b/lib/groovehq/resource_collection.rb
@@ -33,6 +33,8 @@ module GrooveHQ
     end
 
     def each(&block)
+      return enum_for(:each) unless block_given?
+
       collection.each { |item| yield item }
     end
 

--- a/spec/groovehq/client/connection_spec.rb
+++ b/spec/groovehq/client/connection_spec.rb
@@ -106,6 +106,16 @@ describe GrooveHQ::Client::Connection do
       expect(subject.rels[:next]).to be_instance_of(GrooveHQ::Relation)
     end
 
+    context "with request options" do
+      subject { client.get(resource_path, per_page: 20) }
+
+      it "retains options" do
+        stub_request(:get, "#{api_groovehq_url}#{resource_path}?per_page=20").to_return(body: response)
+        expect(subject.options).to eq({})
+      end
+
+    end
+
   end
 
 end

--- a/spec/groovehq/resource_collection_spec.rb
+++ b/spec/groovehq/resource_collection_spec.rb
@@ -43,4 +43,18 @@ describe GrooveHQ::Resource do
 
   end
 
+  context "#each" do
+
+    it "returns an enumerator when block omitted" do
+      data = {
+        tickets: [ { name: "When I am small" } ]
+      }
+
+      resource = GrooveHQ::ResourceCollection.new(client, data)
+      expect(resource.each).to be_instance_of(Enumerator)
+      expect(resource.each.first.name).to eql "When I am small"
+    end
+
+  end
+
 end

--- a/spec/groovehq/resource_collection_spec.rb
+++ b/spec/groovehq/resource_collection_spec.rb
@@ -108,10 +108,9 @@ describe GrooveHQ::Resource do
 
       it "merges data" do
         resource = GrooveHQ::ResourceCollection.new(client, @page_1)
-        resource.each.to_a
 
+        expect(resource.map(&:title)).to eql(["Ticket 1", "Ticket 2", "Ticket 3"])
         expect(resource.collection.size).to eql(3)
-        expect(resource.collection.map(&:title)).to eql(["Ticket 1", "Ticket 2", "Ticket 3"])
       end
 
       it "respects :per_page and other parameters except :page" do
@@ -120,7 +119,7 @@ describe GrooveHQ::Resource do
           with(:headers => {'Authorization'=>'Bearer phantogram'}).
           to_return(:body => {tickets: []}.to_json, status: 200)
 
-        expect(resource.each.to_a.size).to eql(1)
+        expect(resource.map(&:title)).to eql(["Ticket 1"])
       end
     end
 

--- a/spec/groovehq/resource_collection_spec.rb
+++ b/spec/groovehq/resource_collection_spec.rb
@@ -39,6 +39,7 @@ describe GrooveHQ::Resource do
       resource = GrooveHQ::ResourceCollection.new(client, data)
       expect(resource.rels[:next]).to be_instance_of(GrooveHQ::Relation)
       expect(resource.rels[:next].href).to eq("http://api.groovehq.dev/v1/tickets?page=2")
+      expect(resource.rels[:prev]).to be_nil
     end
 
   end

--- a/spec/groovehq/resource_collection_spec.rb
+++ b/spec/groovehq/resource_collection_spec.rb
@@ -113,6 +113,15 @@ describe GrooveHQ::Resource do
         expect(resource.collection.size).to eql(3)
         expect(resource.collection.map(&:title)).to eql(["Ticket 1", "Ticket 2", "Ticket 3"])
       end
+
+      it "respects :per_page and other parameters except :page" do
+        resource = GrooveHQ::ResourceCollection.new(client, @page_1, page: 1, per_page: 20, foo: "bar")
+        stub_request(:get, "http://api.groovehq.dev/v1/tickets?page=2&per_page=20&foo=bar").
+          with(:headers => {'Authorization'=>'Bearer phantogram'}).
+          to_return(:body => {tickets: []}.to_json, status: 200)
+
+        expect(resource.each.to_a.size).to eql(1)
+      end
     end
 
   end

--- a/spec/groovehq/resource_collection_spec.rb
+++ b/spec/groovehq/resource_collection_spec.rb
@@ -56,6 +56,32 @@ describe GrooveHQ::Resource do
       expect(resource.each.first.name).to eql "When I am small"
     end
 
+    it "enumerates all pages" do
+      first_page = {
+        tickets: [{ title: "Ticket 1" }, { title: "Ticket 2" }],
+        meta: {
+          pagination: {
+            next_page: "http://api.groovehq.dev/v1/tickets?page=2"
+          }
+        }
+      }.stringify_keys
+
+      next_page = {
+        tickets: [{ title: "Ticket 3"}],
+        meta: {}
+      }.stringify_keys
+
+      stub_request(:get, "http://api.groovehq.dev/v1/tickets?page=2").
+        with(:headers => {'Authorization'=>'Bearer phantogram'}).
+        to_return(:body => next_page.to_json, status: 200)
+
+      resource = GrooveHQ::ResourceCollection.new(client, first_page)
+
+      all_tickets = resource.each.to_a
+      expect(all_tickets.size).to eql(3)
+
+      expect(all_tickets.map(&:title)).to eql(["Ticket 1", "Ticket 2", "Ticket 3"])
+    end
   end
 
 end

--- a/spec/groovehq/resource_collection_spec.rb
+++ b/spec/groovehq/resource_collection_spec.rb
@@ -53,7 +53,7 @@ describe GrooveHQ::Resource do
 
       resource = GrooveHQ::ResourceCollection.new(client, data)
       expect(resource.each).to be_instance_of(Enumerator)
-      expect(resource.each.first.name).to eql "When I am small"
+      expect(resource.first.name).to eql "When I am small"
     end
 
     context "paginated requests" do
@@ -88,12 +88,12 @@ describe GrooveHQ::Resource do
         }.stringify_keys
 
         stub_request(:get, "http://api.groovehq.dev/v1/tickets?page=2").
-          with(:headers => {'Authorization'=>'Bearer phantogram'}).
-          to_return(:body => page_2.to_json, status: 200)
+          with(headers: {'Authorization' => 'Bearer phantogram'}).
+          to_return(body: page_2.to_json, status: 200)
 
         stub_request(:get, "http://api.groovehq.dev/v1/tickets?page=3").
-          with(:headers => {'Authorization'=>'Bearer phantogram'}).
-          to_return(:body => page_3.to_json, status: 200)
+          with(headers: {'Authorization' => 'Bearer phantogram'}).
+          to_return(body: page_3.to_json, status: 200)
 
         @page_1 = page_1
       end
@@ -116,8 +116,8 @@ describe GrooveHQ::Resource do
       it "respects :per_page and other parameters except :page" do
         resource = GrooveHQ::ResourceCollection.new(client, @page_1, page: 1, per_page: 20, foo: "bar")
         stub_request(:get, "http://api.groovehq.dev/v1/tickets?page=2&per_page=20&foo=bar").
-          with(:headers => {'Authorization'=>'Bearer phantogram'}).
-          to_return(:body => {tickets: []}.to_json, status: 200)
+          with(headers: {'Authorization' => 'Bearer phantogram'}).
+          to_return(body: {tickets: []}.to_json, status: 200)
 
         expect(resource.map(&:title)).to eql(["Ticket 1"])
       end


### PR DESCRIPTION
Opening this PR up for discussion. It's preferable in my opinion for API Ruby clients to embed knowledge of iterating through paged collections with the use of `#each`. A good example of this is the [Twitter gem](https://github.com/sferik/twitter), which provides the ability for enumerable collections to enumerate over each cursor with [recursive calls to each](https://github.com/sferik/twitter/blob/1b74de1ca2b019fd296631c922074e6bd74670f0/lib/twitter/enumerable.rb#L6). 

For the Groove API, we can leverage the pagination rel links. 

This PR demonstrates the change to `ResourceCollection#each`. Some of the tasks are complete, other remain open pending opinions on this change.

- [x] Enumerate all items in a paginated collection via next rel links
- [x] Return an enumerator when no block is given
- [x] Concatenate the results of successive page calls to the current collection, effectively caching the results
- [x] Respect the `per_page` parameter when calling successive pages

This PR also fixes an issue with the rake task for Travis.