### PR TITLE
Call WebMock.enable before all specs in an example group

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,11 @@ require 'webmock/rspec'
 require_relative '../lib/groovehq'
 
 RSpec.configure do |config|
+  config.before :all do
+    WebMock.enable!
+  end
 
   config.before :all, integration: true do
     WebMock.disable!
   end
-
 end


### PR DESCRIPTION
Calling `WebMock.enable!` in a `before :all` block prior to the integration config means example groups can be run in any order without affecting each other's `WebMock` setting.

Addresses issue mentioned in #16 