### PR TITLE
Added spec for passing customer details, not just the email address, …

### DIFF
--- a/spec/groovehq/integration/tickets_spec.rb
+++ b/spec/groovehq/integration/tickets_spec.rb
@@ -25,6 +25,25 @@ describe GrooveHQ::Client::Tickets, integration: true do
       expect(response.summary).to eq options[:body]
     end
 
+      it "successfully can include customer details in ticket" do
+      customer_hash = {
+        email: "customer@example.com",
+        about: "Your internal reference",
+        company_name: "SomeCompany Pty Ltd"
+      }
+
+      options = {
+        body: "Some body text",
+        from: "fodojyko@gmail.com",
+        to: customer_hash
+      }
+      response = client.create_ticket(options)
+      customer = response.rels['customer'].get
+      expect(customer.company_name).to eq customer_hash[:company_name]
+      expect(customer.email).to eq customer_hash[:email]
+      expect(customer.about).to eq customer_hash[:about]
+    end
+
   end
 
   describe "#ticket" do


### PR DESCRIPTION
…when creating a ticket.

I added this to better explain how the hash could be used as a parameter.

It would be handy to externalise the agent_email and customer_email addresses to environment variables too, so other people can easily run the test suite. This would be a bit of a sweeping change across all the specs obvious. For now, I just submitted the values you were using (I used my own values to check the spec passed for me).