### PR TITLE
Fixed failing customers integration spec

### DIFF
--- a/spec/groovehq/integration/customers_spec.rb
+++ b/spec/groovehq/integration/customers_spec.rb
@@ -8,9 +8,9 @@ describe GrooveHQ::Client::Customers, integration: true do
   describe "#update_customer" do
 
     it "updates customer info" do
-      customer = client.customer(customer_email)
       new_about_text = "Some new about text"
       response = client.update_customer(customer_email, about: new_about_text)
+      customer = client.customer(customer_email)
       expect(customer.about).to eq new_about_text
       expect(response.rels[:tickets].href).to eq "http://api.groovehq.com/v1/tickets?customer=#{customer.id}"
     end


### PR DESCRIPTION
There are 3 specs failing, according to Travis:

```
/spec/groovehq/integration/customers_spec.rb:10 # GrooveHQ::Client::Customers#update_customer updates customer info
/spec/groovehq/integration/messages_spec.rb:21 # GrooveHQ::Client::Messages#message successfully gets message
/spec/groovehq/integration/messages_spec.rb:25 # GrooveHQ::Client::Messages#message gets the right message info
```

I've fixed first one, but others fails because message #25662284 they [are referring][1] to probably doesn't exist in your testing groovehq account any more. Please provide a new message id along with a piece of this message's body so that I could fix remaining two specs.

[1]: https://github.com/Fodoj/groovehq/blob/dcedd8cc57b616a65c715cf4401201f8de6881cb/spec/groovehq/integration/messages_spec.rb#L19