### PR TITLE
fix failing customers integration spec

### DIFF
--- a/spec/groovehq/integration/customers_spec.rb
+++ b/spec/groovehq/integration/customers_spec.rb
@@ -8,11 +8,11 @@ describe GrooveHQ::Client::Customers, integration: true do
   describe "#update_customer" do
 
     it "updates customer info" do
-      new_about_text = "Some new about text"
+      new_about_text = "Some new about text " + SecureRandom.uuid
       response = client.update_customer(customer_email, about: new_about_text)
       customer = client.customer(customer_email)
       expect(customer.about).to eq new_about_text
-      expect(response.rels[:tickets].href).to eq "http://api.groovehq.com/v1/tickets?customer=#{customer.id}"
+      expect(response.rels[:tickets]).not_to be_nil
     end
 
   end


### PR DESCRIPTION
There was another failing spec:

```
GrooveHQ::Client::Customers#update_customer updates customer info
Failure/Error: expect(response.rels[:tickets].href).to eq "http://api.groovehq.com/v1/tickets?customer=#{customer.id}"
    expected: "http://api.groovehq.com/v1/tickets?customer=6956710635"
    got: "http://api.groovehq.com/v1/tickets?customer=customer%40example.com"
```

I removed an assumption on a tickets link format from failing test. The reason in my mind was:
 
Hypermedia API gives it's maintainers an advantage to be able to change link format slightly without any damage for clients. They just say "Here are links to this and that, trust us they'll work". Now they changed format and your specs failed, but gem is still working, tickets are still retrievable using this link, nothing is really broken. So failing test lies and it do so because of this unnecessary assumption.

Also I added a bit of randomness to `new_about_text` to be sure that update really happened. Otherwise you cannot say because the old `customer.about` could be the same.

And here are some more thoughts on the topic:

Your gem iself doesn't depend on what links are returned by groovehq API, it just provides them to it's clients as is. Despite this your integration tests do depend on them, in this spec and also [here][1]. Seems like GrooveHQ does some kind of API versioning (this /v1/ in urls), but if they'll change returning links your gem wouldn't become broken but your tests could. Perhaps both of this dependencies should be removed.

[1]: https://github.com/Fodoj/groovehq/blob/master/spec/groovehq/integration/tickets_spec.rb#L41